### PR TITLE
Removes SNMP dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -330,11 +330,6 @@
     </dependency>
     <dependency>
       <groupId>cloud.cosmic</groupId>
-      <artifactId>cloud-plugin-snmp-alerts</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>cloud.cosmic</groupId>
       <artifactId>cloud-plugin-host-anti-affinity</artifactId>
       <version>${project.version}</version>
     </dependency>


### PR DESCRIPTION
The module has been removed but the dependency not. It's breaking the build.
