### PR TITLE
Make cosmic the parent of cosmic-client

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   <packaging>war</packaging>
   <parent>
     <groupId>cloud.cosmic</groupId>
-    <artifactId>cosmic-core</artifactId>
+    <artifactId>cosmic</artifactId>
     <version>5.0.0-SNAPSHOT</version>
   </parent>
   <dependencies>


### PR DESCRIPTION
cosmic-core was the parent of cosmic-client and that introduced a dependency cycle in cosmic. With this change it will be possible to build cosmic in one go.
