### PR TITLE
Do not copy systemvm.zip into WAR

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -644,7 +644,6 @@
                   <target>
                     <copy todir="${basedir}/target/generated-webapp/WEB-INF/classes/vms">
                       <fileset dir="${basedir}/../cosmic-core/systemvm/dist">
-                        <include name="systemvm.zip"/>
                         <include name="systemvm.iso"/>
                       </fileset>
                     </copy>


### PR DESCRIPTION
systemvm.zip is only used to create the systemvm.iso and by the HyperV plugin which we don't support.
So, this PR removes it from the WAR file.

Also, the new packing script for cosmic KVM agents does not use it.
