### PR TITLE
Fix typo in image name resulting in 404

### DIFF
--- a/cosmic-ui/css/cloudstack3.css
+++ b/cosmic-ui/css/cloudstack3.css
@@ -57,7 +57,7 @@ body.install-wizard {
   height: 769px !important;
   overflow: auto;
   overflow-x: hidden;
-  background: #FFFFFF url(../images/bg-login-cosmic.png);
+  background: #FFFFFF url(../images/bg-login.png);
 }
 
 #main-area {
@@ -345,7 +345,7 @@ table th div.ui-resizable-handle {
 
 /*Login screen*/
 body.login {
-  background: url(../images/overlay-pattern.png) repeat center, #2c2c2c url(../images/bg-login-cosmic.png) no-repeat center;
+  background: url(../images/overlay-pattern.png) repeat center, #2c2c2c no-repeat center;
   background-size: auto, cover;
   overflow: hidden;
 }


### PR DESCRIPTION
Removed it from login page as we do not need it there.

Error seen:
![screen shot 2016-03-29 at 22 10 36](https://cloud.githubusercontent.com/assets/1630096/14122478/4f744a22-f5fc-11e5-91ff-cfe81843de8b.png)
