### PR TITLE
When no zone name is available display a default

### DIFF
--- a/cosmic-ui/scripts/templates.js
+++ b/cosmic-ui/scripts/templates.js
@@ -1426,6 +1426,9 @@
                                                             else
                                                                 jsonObj.xenserverToolsVersion61plus = false;
                                                         }
+                                                        if (!'zonename' in jsonObj) {
+                                                            jsonObj.zonename = 'All Zones';
+                                                        }
                                                     }
                                                 }
 


### PR DESCRIPTION
When a zone name is available, the previous behaviour is still there:
![screen shot 2016-03-30 at 21 00 44](https://cloud.githubusercontent.com/assets/1630096/14154026/ba41a4bc-f6ba-11e5-9f88-19cf36bfbd4f.png)

When there is no zone name, it used to display an empty name (where you had to click on to see details):
![screen shot 2016-03-30 at 21 03 06](https://cloud.githubusercontent.com/assets/1630096/14154048/d31a7b08-f6ba-11e5-9f67-f716e8d9fbf2.png)

With this change, a default name `All` is displayed (because this happens when S3 storage is used that is region wide aka all zones):
![screen shot 2016-03-30 at 20 53 50](https://cloud.githubusercontent.com/assets/1630096/14154060/e20d1d0a-f6ba-11e5-9b0a-1b5e502a2964.png)

Region wide S3:
![screen shot 2016-03-30 at 21 04 55](https://cloud.githubusercontent.com/assets/1630096/14154108/2222ff54-f6bb-11e5-845a-c22ddc745b98.png)
