### PR TITLE
Define cloud-nucleo dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
     <dependency>
       <groupId>cloud.cosmic</groupId>
       <artifactId>cloud-nucleo</artifactId>
-      <version>${project.version}</version>
+      <version>5.0.0.1-SNAPSHOT</version>
       <type>jar</type>
     </dependency>
     <dependency>


### PR DESCRIPTION
Without this change, we can't update the version to a release version automatically by calling `mvn versions:use-releases`.
We need to do that as part of the automated release process.
