### PR TITLE
Allow a volume to be migrated to any storage pool via UI

### DIFF
--- a/cosmic-ui/scripts/instances.js
+++ b/cosmic-ui/scripts/instances.js
@@ -1649,7 +1649,158 @@
                             poll: pollAsyncJobResult
                         }
                     },
+                    scaleUp: {
+                        label: 'label.change.service.offering',
+                        createForm: {
+                            title: 'label.change.service.offering',
+                            desc: function(args) {
+                                var description = '';
+                                var vmObj = args.jsonObj;
+                                if (vmObj.state == 'Running' && vmObj.hypervisor == 'VMware') {
+                                    description = 'message.read.admin.guide.scaling.up';
+                                }
+                                return description;
+                            },
+                            fields: {
+                                serviceofferingid: {
+                                    label: 'label.compute.offering',
+                                    select: function(args) {
+                                        var serviceofferingObjs;
+                                        $.ajax({
+                                            url: createURL("listServiceOfferings&VirtualMachineId=" + args.context.instances[0].id),
+                                            dataType: "json",
+                                            async: true,
+                                            success: function(json) {
+                                                serviceofferingObjs = json.listserviceofferingsresponse.serviceoffering;
+                                                var items = [];
+                                                if (serviceofferingObjs != null) {
+                                                    for (var i = 0; i < serviceofferingObjs.length; i++) {
+                                                        items.push({
+                                                            id: serviceofferingObjs[i].id,
+                                                            description: serviceofferingObjs[i].name
+                                                        });
+                                                    }
+                                                }
+                                                args.response.success({
+                                                    data: items
+                                                });
+                                            }
+                                        });
 
+                                        args.$select.change(function(){
+                                            var $form = $(this).closest('form');
+
+                                            var serviceofferingid = $(this).val();
+                                            if (serviceofferingid == null || serviceofferingid.length == 0)
+                                                return;
+
+                                            var items = [];
+                                            var selectedServiceofferingObj;
+                                            if (serviceofferingObjs != null) {
+                                                for (var i = 0; i < serviceofferingObjs.length; i++) {
+                                                    if (serviceofferingObjs[i].id == serviceofferingid) {
+                                                        selectedServiceofferingObj = serviceofferingObjs[i];
+                                                        break;
+                                                    }
+                                                }
+                                            }
+                                            if (selectedServiceofferingObj == undefined)
+                                                return;
+
+                                            if (selectedServiceofferingObj.iscustomized == true) {
+                                                $form.find('.form-item[rel=cpuSpeed]').css('display', 'inline-block');
+                                                $form.find('.form-item[rel=cpuNumber]').css('display', 'inline-block');
+                                                $form.find('.form-item[rel=memory]').css('display', 'inline-block');
+                                            } else {
+                                                $form.find('.form-item[rel=cpuSpeed]').hide();
+                                                $form.find('.form-item[rel=cpuNumber]').hide();
+                                                $form.find('.form-item[rel=memory]').hide();
+                                            }
+                                        });
+                                    }
+                                },
+                                cpuSpeed: {
+                                    label: 'label.cpu.mhz',
+                                    validation: {
+                                        required: true,
+                                        number: true
+                                    },
+                                    isHidden: true
+                                },
+                                cpuNumber: {
+                                    label: 'label.num.cpu.cores',
+                                    validation: {
+                                        required: true,
+                                        number: true
+                                    },
+                                    isHidden: true
+                                },
+                                memory: {
+                                    label: 'label.memory.mb',
+                                    validation: {
+                                        required: true,
+                                        number: true
+                                    },
+                                    isHidden: true
+                                }
+                            }
+                        },
+
+                        action: function(args) {
+                            var data = {
+                                id: args.context.instances[0].id,
+                                serviceofferingid: args.data.serviceofferingid
+                            };
+
+                            if (args.$form.find('.form-item[rel=cpuSpeed]').is(':visible')) {
+                                $.extend(data, {
+                                    'details[0].cpuSpeed': args.data.cpuSpeed
+                                });
+                            }
+                            if (args.$form.find('.form-item[rel=cpuNumber]').is(':visible')) {
+                                $.extend(data, {
+                                    'details[0].cpuNumber': args.data.cpuNumber
+                                });
+                            }
+                            if (args.$form.find('.form-item[rel=memory]').is(':visible')) {
+                                $.extend(data, {
+                                    'details[0].memory': args.data.memory
+                                });
+                            }
+
+                            $.ajax({
+                                url: createURL('scaleVirtualMachine'),
+                                data: data,
+                                success: function(json) {
+                                    var jid = json.scalevirtualmachineresponse.jobid;
+                                    args.response.success({
+                                        _custom: {
+                                            jobId: jid,
+                                            getUpdatedItem: function(json) {
+                                                return json.queryasyncjobresultresponse.jobresult.virtualmachine;
+                                            },
+                                            getActionFilter: function() {
+                                                return vmActionfilter;
+                                            }
+                                        }
+                                    });
+
+                                },
+                                error: function(json) {
+                                    args.response.error(parseXMLHttpResponse(json));
+                                }
+
+                            });
+                        },
+                        messages: {
+                            notification: function(args) {
+                                return 'label.change.service.offering';  //CLOUDSTACK-7744
+                            }
+                        },
+                        notification: {
+                            poll: pollAsyncJobResult
+                        }
+                    },
                     resetSSHKeyForVirtualMachine: {
                         label: 'label.reset.ssh.key.pair',
                         createForm: {

--- a/cosmic-ui/scripts/storage.js
+++ b/cosmic-ui/scripts/storage.js
@@ -745,11 +745,11 @@
                                             },
                                             select: function(args) {
                                                 $.ajax({
-                                                    url: createURL("findStoragePoolsForMigration&id=" + args.context.volumes[0].id),
+                                                    url: createURL("listStoragePools"),
                                                     dataType: "json",
                                                     async: true,
                                                     success: function(json) {
-                                                        var pools = json.findstoragepoolsformigrationresponse.storagepool;
+                                                        var pools = json.liststoragepoolsresponse.storagepool;
                                                         var items = [];
                                                         $(pools).each(function() {
                                                             items.push({


### PR DESCRIPTION
`findStoragePoolsForMigration` limits the pool to only those it thinks are 'suitable'. In reality, when the VM is powered down, you can migrate to any storage pool (as you get with `listStoragePools` api). 
In CloudMonkey this is already possible, so why not have the UI do it too? This PR fixes that. It allows for easy switching between different offerings / pools. This PR builds on top of #49.

Before (empty list):
![screen shot 2016-05-15 at 22 31 42](https://cloud.githubusercontent.com/assets/1630096/15276597/d83ce0ca-1aec-11e6-9b7c-6d79ca402549.png)

After (can choose any storage pool):
![screen shot 2016-05-15 at 22 24 39](https://cloud.githubusercontent.com/assets/1630096/15276581/721340dc-1aec-11e6-9032-a3664f2eb388.png)

When you try this when a VM is still running you get a nice message saying you need to stop the VM in order to migrate to another cluster. In another PR I made that message more descriptive.
