### PR TITLE
Fix service offerings tab after PR #41

### DIFF
--- a/cosmic-ui/scripts/configuration.js
+++ b/cosmic-ui/scripts/configuration.js
@@ -2526,7 +2526,7 @@
                                         }
 
                                         //show LB Isolation dropdown only when (1)LB Service is checked
-                                        if ((args.$form.find('.form-item[rel=\"service.Lb.isEnabled\"]').find('input[type=checkbox]').is(':checked') == true) {
+                                        if (args.$form.find('.form-item[rel=\"service.Lb.isEnabled\"]').find('input[type=checkbox]').is(':checked') == true) {
                                             args.$form.find('.form-item[rel=\"service.Lb.lbIsolationDropdown\"]').css('display', 'inline-block');
                                         } else {
                                             args.$form.find('.form-item[rel=\"service.Lb.lbIsolationDropdown\"]').hide();


### PR DESCRIPTION
The ServiceOfferings tab didn't display due to a syntax error introduced in #41. It's fixed now.

Before:
![serviceofferings-broken](https://cloud.githubusercontent.com/assets/1630096/15321187/2fe0d16c-1c35-11e6-8d7a-d20a274a9074.png)

After:
![serviceofferings-ok](https://cloud.githubusercontent.com/assets/1630096/15321204/416d06b2-1c35-11e6-8f8d-145f35287115.png)
