### PR TITLE
Improve VPC tier details tab

### DIFF
--- a/cosmic-ui/scripts/docs.js
+++ b/cosmic-ui/scripts/docs.js
@@ -892,7 +892,7 @@ cloudStack.docs = {
         externalLink: ''
     },
     helpTierGateway: {
-        desc: 'The gateway for the tier. Must be in the Super CIDR range of the VPC and not overlapping the CIDR of any other tier in this VPC.',
+        desc: 'The gateway for VMs in the tier. Must be in the Super CIDR range of the VPC and not overlapping the CIDR of any other tier in this VPC. On the specified ip-address, the VPC router will act as the gateway for VMs on this tier. When used in combination with a VPC offering without SNAT (bridged networks) the gateway is expected to pre-exist on the network. The VPC router will just hand out this gateway ip address over DHCP to VMs. In which case it does not act as the gateway itself.',
         externalLink: ''
     },
     helpTierNetmask: {

--- a/cosmic-ui/scripts/vpc.js
+++ b/cosmic-ui/scripts/vpc.js
@@ -3868,7 +3868,6 @@
                                                     forvpc: true,
                                                     zoneid: args.zoneId,
                                                     guestiptype: 'Isolated',
-                                                    supportedServices: 'SourceNat',
                                                     state: 'Enabled'
                                                 },
                                                 success: function(json) {

--- a/cosmic-ui/scripts/vpc.js
+++ b/cosmic-ui/scripts/vpc.js
@@ -3408,10 +3408,7 @@
                             if (args.context.networks[0].type == "Isolated") {
                                 hiddenFields.push("networkofferingdisplaytext");
                                 hiddenFields.push("networkdomaintext");
-                                //hiddenFields.push("gateway");
-                                //hiddenFields.push("networkofferingname");
-                                //hiddenFields.push("netmask");
-                            } else { //selectedGuestNetworkObj.type == "Shared"
+                            } else {
                                 hiddenFields.push("networkofferingid");
                                 hiddenFields.push("networkdomain");
                             }
@@ -3520,7 +3517,6 @@
                                     });
                                 }
                             },
-                            //aclid:{label:'ACL id'},
                             id: {
                                 label: 'label.id'
                             }

--- a/cosmic-ui/scripts/vpc.js
+++ b/cosmic-ui/scripts/vpc.js
@@ -3408,8 +3408,8 @@
                             if (args.context.networks[0].type == "Isolated") {
                                 hiddenFields.push("networkofferingdisplaytext");
                                 hiddenFields.push("networkdomaintext");
-                                hiddenFields.push("gateway");
-                                hiddenFields.push("networkofferingname");
+                                //hiddenFields.push("gateway");
+                                //hiddenFields.push("networkofferingname");
                                 //hiddenFields.push("netmask");
                             } else { //selectedGuestNetworkObj.type == "Shared"
                                 hiddenFields.push("networkofferingid");
@@ -3423,15 +3423,40 @@
                                 isEditable: true
                             }
                         }, {
-                            id: {
-                                label: 'label.id'
+                            displaytext: {
+                                label: 'label.description',
+                                isEditable: true
+                            },
+                            cidr: {
+                                label: 'label.cidr'
+                            },
+                            gateway: {
+                                label: 'label.gateway'
+                            },
+                            netmask: {
+                                label: 'Netmask'
+                            },
+                            networkdomaintext: {
+                                label: 'label.network.domain.text'
+                            },
+                            networkdomain: {
+                                label: 'label.network.domain',
+                                isEditable: true
+                            },
+                            vlan: {
+                                label: 'label.vlan.id'
+                            },
+                            aclname: {
+                                label: 'label.acl.name'
                             },
                             zonename: {
                                 label: 'label.zone'
                             },
-                            displaytext: {
-                                label: 'label.description',
-                                isEditable: true
+                            domain: {
+                                label: 'label.domain'
+                            },
+                            account: {
+                                label: 'label.account'
                             },
                             type: {
                                 label: 'label.type'
@@ -3439,7 +3464,6 @@
                             state: {
                                 label: 'label.state'
                             },
-
                             ispersistent: {
                                 label: 'label.persistent',
                                 converter: cloudStack.converters.toBooleanText
@@ -3455,14 +3479,9 @@
                                         return "No";
                                 }
                             },
-                            vlan: {
-                                label: 'label.vlan.id'
-                            },
-
                             networkofferingname: {
                                 label: 'label.network.offering'
                             },
-
                             networkofferingid: {
                                 label: 'label.network.offering',
                                 isEditable: true,
@@ -3501,34 +3520,9 @@
                                     });
                                 }
                             },
-
-                            gateway: {
-                                label: 'label.gateway'
-                            },
-
-                            //netmask: { label: 'Netmask' },
-                            cidr: {
-                                label: 'label.cidr'
-                            },
-
-                            networkdomaintext: {
-                                label: 'label.network.domain.text'
-                            },
-                            networkdomain: {
-                                label: 'label.network.domain',
-                                isEditable: true
-                            },
-
-                            aclname: {
-                                label: 'label.acl.name'
-                            },
                             //aclid:{label:'ACL id'},
-
-                            domain: {
-                                label: 'label.domain'
-                            },
-                            account: {
-                                label: 'label.account'
+                            id: {
+                                label: 'label.id'
                             }
                         }],
                         dataProvider: function(args) {


### PR DESCRIPTION
- Display the most important info about tiers at the top (gateway was missing completely).
- Improve help messages
- Allow selecting a network offering without sourcenat service (currently there are none, this will be introduced in a separate PR against cosmic-core)

Details tab after:
![screen shot 2016-05-18 at 10 17 25](https://cloud.githubusercontent.com/assets/1630096/15554361/146b1b32-22c4-11e6-935b-8f701393d5ec.png)

Details tab before:
![screen shot 2016-05-18 at 10 15 26](https://cloud.githubusercontent.com/assets/1630096/15554367/19f3beec-22c4-11e6-9a5b-c8aacd29881d.png)
