### PR TITLE
Static route display in the UI

### DIFF
--- a/WEB-INF/classes/resources/messages.properties
+++ b/WEB-INF/classes/resources/messages.properties
@@ -2131,6 +2131,7 @@ state.Suspended=Suspended
 ui.listView.filters.all=All
 ui.listView.filters.mine=Mine
 label.na=N/A
+label.nexthop=Nexthop
 label.added.network.offering=Added network offering
 hint.type.part.storage.tag=Type in part of a storage tag
 hint.type.part.host.tag=Type in part of a host tag

--- a/cosmic-ui/dictionary.jsp
+++ b/cosmic-ui/dictionary.jsp
@@ -460,6 +460,7 @@ dictionary = {
 'label.cidr.list': '<fmt:message key="label.cidr.list" />',
 'label.CIDR.list': '<fmt:message key="label.CIDR.list" />',
 'label.CIDR.of.destination.network': '<fmt:message key="label.CIDR.of.destination.network" />',
+'label.nexthop': '<fmt:message key="label.nexthop" />',
 'label.clean.up': '<fmt:message key="label.clean.up" />',
 'label.make.redundant': '<fmt:message key="label.make.redundant" />',
 'label.clear.list': '<fmt:message key="label.clear.list" />',

--- a/cosmic-ui/scripts/network.js
+++ b/cosmic-ui/scripts/network.js
@@ -5819,6 +5819,105 @@
                                         }
                                     });
                                 }
+                            },
+                            staticRoutes: {
+                                title: 'label.static.routes',
+                                custom: function(args) {
+                                    return $('<div>').multiEdit({
+                                        noSelect: true,
+                                        context: args.context,
+                                        fields: {
+                                            cidr: {
+                                                edit: true,
+                                                label: 'label.CIDR.of.destination.network'
+                                            },
+                                            nexthop: {
+                                                edit: true,
+                                                label: 'label.nexthop'
+                                            },
+                                            'add-rule': {
+                                                label: 'label.add.route',
+                                                addButton: true
+                                            }
+                                        },
+
+                                        tags: cloudStack.api.tags({
+                                            resourceType: 'StaticRoute',
+                                            contextId: 'multiRule'
+                                        }),
+
+                                        add: {
+                                            label: 'label.add',
+                                            action: function(args) {
+                                                $.ajax({
+                                                    url: createURL('createStaticRoute'),
+                                                    data: {
+                                                        vpcid: args.context.vpc[0].id,
+                                                        cidr: args.data.cidr,
+                                                        nexthop: args.data.nexthop
+                                                    },
+                                                    success: function(data) {
+                                                        args.response.success({
+                                                            _custom: {
+                                                                jobId: data.createstaticrouteresponse.jobid
+                                                            },
+                                                            notification: {
+                                                                label: 'label.add.static.route',
+                                                                poll: pollAsyncJobResult
+                                                            }
+                                                        });
+                                                    },
+                                                    error: function(data) {
+                                                        args.response.error(parseXMLHttpResponse(data));
+                                                    }
+                                                });
+                                            }
+                                        },
+                                        actions: {
+                                            destroy: {
+                                                label: 'label.remove.static.route',
+                                                action: function(args) {
+                                                    $.ajax({
+                                                        url: createURL('deleteStaticRoute'),
+                                                        data: {
+                                                            id: args.context.multiRule[0].id
+                                                        },
+                                                        dataType: 'json',
+                                                        async: true,
+                                                        success: function(data) {
+                                                            var jobID = data.deletestaticrouteresponse.jobid;
+
+                                                            args.response.success({
+                                                                _custom: {
+                                                                    jobId: jobID
+                                                                },
+                                                                notification: {
+                                                                    label: 'label.remove.static.route',
+                                                                    poll: pollAsyncJobResult
+                                                                }
+                                                            });
+                                                        }
+                                                    });
+                                                }
+                                            }
+                                        },
+                                        dataProvider: function(args) {
+                                            $.ajax({
+                                                url: createURL('listStaticRoutes'),
+                                                data: {
+                                                    vpcid: args.context.vpc[0].id,
+                                                    listAll: true
+                                                },
+                                                success: function(json) {
+                                                    var items = json.liststaticroutesresponse.staticroute;
+                                                    args.response.success({
+                                                        data: items
+                                                    });
+                                                }
+                                            });
+                                        }
+                                    });
+                                }
                             }
                         }
                     }

--- a/cosmic-ui/scripts/vpc.js
+++ b/cosmic-ui/scripts/vpc.js
@@ -2454,8 +2454,9 @@
                                                     $.ajax({
                                                         url: createURL('createStaticRoute'),
                                                         data: {
-                                                            gatewayid: args.context.vpcGateways[0].id,
-                                                            cidr: args.data.cidr
+                                                            vpcid: args.context.vpc[0].id,
+                                                            cidr: args.data.cidr,
+                                                            nexthop: args.context.vpcGateways[0].gateway
                                                         },
                                                         success: function(data) {
                                                             args.response.success({
@@ -2507,6 +2508,7 @@
                                                     url: createURL('listStaticRoutes'),
                                                     data: {
                                                         gatewayid: args.context.vpcGateways[0].id,
+                                                        vpcid: args.context.vpc[0].id,
                                                         listAll: true
                                                     },
                                                     success: function(json) {


### PR DESCRIPTION
Added a tab on the VPC details to show/set static routes.
![screen shot 2016-05-31 at 23 53 11](https://cloud.githubusercontent.com/assets/1630096/15691909/ba4b5280-278b-11e6-9d42-3a3fe011704a.png)

The original private gw static route view also still works.
![screen shot 2016-05-31 at 23 54 16](https://cloud.githubusercontent.com/assets/1630096/15691910/bc4070f2-278b-11e6-89d7-c8bfe0a21fee.png)

To be merged together with https://github.com/MissionCriticalCloud/cosmic-core/pull/167
