### PR TITLE
Remove dependency on cloud-plugin-network-elb.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,11 +91,6 @@
     </dependency>
     <dependency>
       <groupId>cloud.cosmic</groupId>
-      <artifactId>cloud-plugin-network-elb</artifactId>
-      <version>5.1.0.0-SNAPSHOT</version>
-    </dependency>
-    <dependency>
-      <groupId>cloud.cosmic</groupId>
       <artifactId>cloud-plugin-network-internallb</artifactId>
       <version>5.1.0.0-SNAPSHOT</version>
     </dependency>


### PR DESCRIPTION
Left over of the removal of the cloud-plugin-network-elb plugin.

Integration tests are running: https://beta-jenkins.mcc.schubergphilis.com/job/cosmic/job/0002-tracking-repo-branch-build/167/
