### PR TITLE
Allow only root admin to create/edit service offerings

### DIFF
--- a/cosmic-ui/scripts/configuration.js
+++ b/cosmic-ui/scripts/configuration.js
@@ -30,7 +30,7 @@
                if(isAdmin())
                    return ["serviceOfferings", "systemServiceOfferings", "diskOfferings", "networkOfferings", "vpcOfferings"];
                else if(isDomainAdmin())
-                   return ["serviceOfferings", "diskOfferings"];
+                   return [""];
                else
                    return null;
             },

--- a/tomcatconf/commands.properties.in
+++ b/tomcatconf/commands.properties.in
@@ -135,9 +135,9 @@ updateGuestOsMapping=1
 removeGuestOsMapping=1
 
 #### service offering commands
-createServiceOffering=7
-deleteServiceOffering=7
-updateServiceOffering=7
+createServiceOffering=3
+deleteServiceOffering=3
+updateServiceOffering=3
 listServiceOfferings=15
 
 #### disk offering commands


### PR DESCRIPTION
Currently domain admins are allowed to create service offerings and this results to customers creating offerings that do not have the required tags. This PR limits this to root admins only.

Integration tests running here:
https://beta-jenkins.mcc.schubergphilis.com/job/cosmic/job/0002-tracking-repo-branch-build/173/
